### PR TITLE
Corrected path error in script

### DIFF
--- a/extra/payloads/ReverseOpenSSH/publicMachine/configPublic.sh
+++ b/extra/payloads/ReverseOpenSSH/publicMachine/configPublic.sh
@@ -15,7 +15,7 @@ printf "setting a new password for user\n"
 passwd user
 # make main machine authorized to log in as user, give user a normal shell
 cp ./user/authorized_keys /home/user/.ssh/authorized_keys
-chmod 644 /home/user/authorized_keys
+chmod 644 /home/user/.ssh/authorized_keys
 chown -R user:user /home/user
 chsh -s /bin/bash user
 
@@ -27,7 +27,7 @@ printf "setting a new password for peasant\n"
 passwd peasant
 # make target machine authorized to log in as peasant, prevent any command execution
 cp ./peasant/authorized_keys /home/peasant/.ssh/authorized_keys
-chmod 644 /home/peasant/authorized_keys
+chmod 644 /home/peasant/.ssh/authorized_keys
 chown -R peasant:peasant /home/peasant
 chsh -s /bin/true peasant
 


### PR DESCRIPTION
There was a simple error in the path to the authorized_keys files used in the script when setting up the user accounts on the public machine